### PR TITLE
Remove animation during drag gesture

### DIFF
--- a/swipebox/src/main/java/com/kevinnzou/compose/swipebox/AnchoredDragBox.kt
+++ b/swipebox/src/main/java/com/kevinnzou/compose/swipebox/AnchoredDragBox.kt
@@ -96,16 +96,12 @@ fun AnchoredDragBox(
         SwipeDirection.EndToStart -> Float.NEGATIVE_INFINITY..0f
         SwipeDirection.Both -> Float.NEGATIVE_INFINITY..Float.POSITIVE_INFINITY
     }
-    val startSwipeProgress by animateFloatAsState(
-        targetValue = if (state.requireOffset() > 0f) {
-            (state.requireOffset() / startWidthPx).absoluteValue
-        } else 0f, label = "startSwipeProgress"
-    )
-    val endSwipeProgress by animateFloatAsState(
-        targetValue = if (state.requireOffset() < 0f) {
-            (state.requireOffset() / endWidthPx).absoluteValue
-        } else 0f, label = "endSwipeProgress"
-    )
+    val startSwipeProgress = if (state.requireOffset() > 0f) {
+        (state.requireOffset() / startWidthPx).absoluteValue
+    } else 0f
+    val endSwipeProgress = if (state.requireOffset() < 0f) {
+        (state.requireOffset() / endWidthPx).absoluteValue
+    } else 0f
     val startContentLiveWidth = startContentWidth * startSwipeProgress
     val endContentLiveWidth = endContentWidth * endSwipeProgress
     Box(


### PR DESCRIPTION
This keeps the revealed content in sync with the translation of the row as the user drags.

[swipe_box.webm](https://github.com/KevinnZou/compose-swipeBox/assets/6461398/1e2973a6-d13d-486a-bec9-cfb1361d753f)